### PR TITLE
Add responsive sidenav

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,23 @@
-<mat-toolbar color="primary">
-  <span>Devis Artisan</span>
-</mat-toolbar>
-<div class="container">
-  <router-outlet></router-outlet>
-</div>
+<mat-sidenav-container class="sidenav-container">
+  <mat-sidenav
+    #sidenav
+    [mode]="isSmallScreen ? 'over' : 'side'"
+    [opened]="!isSmallScreen"
+  >
+    <mat-nav-list>
+      <a mat-list-item routerLink="/devis" (click)="isSmallScreen && sidenav.close()">Devis</a>
+    </mat-nav-list>
+  </mat-sidenav>
+
+  <mat-sidenav-content>
+    <mat-toolbar color="primary">
+      <button *ngIf="isSmallScreen" mat-icon-button (click)="sidenav.toggle()">
+        <mat-icon>menu</mat-icon>
+      </button>
+      <span>Devis Artisan</span>
+    </mat-toolbar>
+    <div class="container">
+      <router-outlet></router-outlet>
+    </div>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,3 +1,7 @@
+.sidenav-container {
+  height: 100vh;
+}
+
 .container {
   padding: 1rem;
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,16 +1,36 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatListModule } from '@angular/material/list';
+import { BreakpointObserver } from '@angular/cdk/layout';
 import { Item, PdfService } from './pdf.service';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, MatToolbarModule],
+  imports: [
+    RouterOutlet,
+    MatToolbarModule,
+    MatSidenavModule,
+    MatIconModule,
+    MatButtonModule,
+    MatListModule,
+  ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
 export class AppComponent {
   title = 'invoice-app';
+
+  isSmallScreen = false;
+
+  constructor(private breakpointObserver: BreakpointObserver) {
+    this.breakpointObserver
+      .observe('(max-width: 768px)')
+      .subscribe(result => (this.isSmallScreen = result.matches));
+  }
 
   private pdf = new PdfService();
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,9 @@
 @import '@angular/material/prebuilt-themes/indigo-pink.css';
 
+html, body {
+  height: 100%;
+}
+
 body {
   margin: 0;
   font-family: Roboto, Arial, sans-serif;


### PR DESCRIPTION
## Summary
- implement `MatSidenav` layout with menu icon
- use `BreakpointObserver` to hide sidebar on small screens
- adjust global and component styles for full height

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2994e14c8332bd36d7cfd9a80f4f