### PR TITLE
Add responsive sidebar toggle

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <mat-sidenav-container class="sidenav-container">
-  <mat-sidenav mode="side" opened>
+  <mat-sidenav #drawer [mode]="(isSmallScreen$ | async) ? 'over' : 'side'" [opened]="!(isSmallScreen$ | async)">
     <mat-nav-list>
       <a mat-list-item routerLink="/devis">Devis</a>
       <a mat-list-item routerLink="/facture">Facture</a>
@@ -7,6 +7,9 @@
   </mat-sidenav>
   <mat-sidenav-content>
     <mat-toolbar color="primary">
+      <button mat-icon-button (click)="drawer.toggle()" *ngIf="isSmallScreen$ | async" aria-label="Menu">
+        <mat-icon>menu</mat-icon>
+      </button>
       <span>Devis Artisan</span>
     </mat-toolbar>
     <div class="container">

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -5,3 +5,7 @@
 .container {
   padding: 1rem;
 }
+
+mat-toolbar button {
+  margin-right: 1rem;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,6 +4,10 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { Observable } from 'rxjs';
+import { map, shareReplay } from 'rxjs/operators';
 import { Item, PdfService } from './pdf.service';
 
 @Component({
@@ -14,7 +18,8 @@ import { Item, PdfService } from './pdf.service';
     MatToolbarModule,
     MatSidenavModule,
     MatListModule,
-    MatIconModule
+    MatIconModule,
+    MatButtonModule
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
@@ -22,7 +27,16 @@ import { Item, PdfService } from './pdf.service';
 export class AppComponent {
   title = 'invoice-app';
 
+  isSmallScreen$: Observable<boolean> = this.breakpointObserver
+    .observe([Breakpoints.Handset, Breakpoints.Tablet])
+    .pipe(
+      map(result => result.matches),
+      shareReplay()
+    );
+
   private pdf = new PdfService();
+
+  constructor(private breakpointObserver: BreakpointObserver) {}
 
   generate() {
     const items: Item[] = [


### PR DESCRIPTION
## Summary
- show a button with `mat-icon` to toggle the side nav on small screens
- hide the side nav when viewport width is tablet size or smaller using `BreakpointObserver`
- add spacing for toolbar icon

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng test --watch=false` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_684b2d66c0dc833296bd51b93caf039e